### PR TITLE
Fix issues when running make test

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -166,9 +166,9 @@ func TestFieldGenerationWithArrayReferences(t *testing.T) {
 	}
 
 	testField(g.Structs["TestFieldGenerationWithArrayReferences"].Fields["Property1"], "property1", "Property1", "string", false, t)
-	testField(g.Structs["TestFieldGenerationWithArrayReferences"].Fields["Property2"], "property2", "Property2", "[]*Address", true, t)
+	testField(g.Structs["TestFieldGenerationWithArrayReferences"].Fields["Property2"], "property2", "Property2", "[]Address", true, t)
 	testField(g.Structs["TestFieldGenerationWithArrayReferences"].Fields["Property3"], "property3", "Property3", "[]map[string]int", false, t)
-	testField(g.Structs["TestFieldGenerationWithArrayReferences"].Fields["Property4"], "property4", "Property4", "[][]*Inner", false, t)
+	testField(g.Structs["TestFieldGenerationWithArrayReferences"].Fields["Property4"], "property4", "Property4", "[][]Inner", false, t)
 }
 
 func testField(actual Field, expectedJSONName string, expectedName string, expectedType string, expectedToBeRequired bool, t *testing.T) {
@@ -430,8 +430,8 @@ func TestNestedArrayGeneration(t *testing.T) {
 	if !ok {
 		t.Errorf("Expected to find the Cities field on the FavouriteBars, but didn't. The struct is %+v", fbStruct)
 	}
-	if f.Type != "[]*City" {
-		t.Errorf("Expected to find that the Cities array was of type *City, but it was of %s", f.Type)
+	if f.Type != "[]City" {
+		t.Errorf("Expected to find that the Cities array was of type []City, but it was of %s", f.Type)
 	}
 
 	f, ok = fbStruct.Fields["Tags"]
@@ -719,7 +719,7 @@ func TestTypeAliases(t *testing.T) {
 			aliases: 1,
 		},
 		{
-			gotype: "[]*Foo",
+			gotype: "[]Foo",
 			input: &Schema{TypeValue: "array",
 				Items: &Schema{
 					TypeValue: "object",

--- a/test/abandoned_test.go
+++ b/test/abandoned_test.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"testing"
+
+	abandoned "github.com/elastic/go-json-schema-generate/test/abandoned_gen"
 )
 
 func TestAbandoned(t *testing.T) {

--- a/test/additionalProperties2_test.go
+++ b/test/additionalProperties2_test.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"reflect"
 	"testing"
+
+	additionalProperties2 "github.com/elastic/go-json-schema-generate/test/additionalProperties2_gen"
 )
 
 func TestMarshalUnmarshal(t *testing.T) {
@@ -37,7 +39,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 						"red": {
 							"blue": {
 								Color: "green",
-								Conditions: []*additionalProperties2.ConditionsItems{
+								Conditions: []additionalProperties2.ConditionsItems{
 									{Name: "dry"},
 								},
 								Density: 42.42,

--- a/test/example1_test.go
+++ b/test/example1_test.go
@@ -3,6 +3,8 @@ package test
 import (
 	"encoding/json"
 	"testing"
+
+	example1 "github.com/elastic/go-json-schema-generate/test/example1_gen"
 )
 
 func TestExample1(t *testing.T) {


### PR DESCRIPTION
Fix issues that occur when running make test.
One issue is that test files in test/ do not have the corrected imports
for our fork of the repo. The second issue is that an earlier commit of
ours (5672148f3c31d78bbd0124583bc20133f2e18f37) strips pointers from array subtypes.