### PR TITLE
Support for decoding string/date-time to time.Time

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -201,6 +201,9 @@ func (g *Generator) processObject(name string, schema *Schema, conventions map[s
 			Description: prop.Description,
 			Format:      prop.Format,
 		}
+		if f.Type == "string" && f.Format == "date-time" {
+			strct.importTypes = append(strct.importTypes, "time")
+		}
 		if f.Required {
 			strct.GenerateCode = true
 		}
@@ -324,7 +327,7 @@ func (g *Generator) getSchemaName(keyName string, schema *Schema, conventions ma
 		return getGolangName(schema.JSONKey, conventions)
 	}
 	if schema.Parent != nil && schema.Parent.JSONKey != "" {
-		return getGolangName(schema.Parent.JSONKey + "Item", conventions)
+		return getGolangName(schema.Parent.JSONKey+"Item", conventions)
 	}
 	g.anonCount++
 	return fmt.Sprintf("Anonymous%d", g.anonCount)
@@ -395,6 +398,7 @@ type Struct struct {
 
 	GenerateCode   bool
 	AdditionalType string
+	importTypes    []string // addition packages to include when importing
 }
 
 // Field defines the data required to generate a field in Go.

--- a/output.go
+++ b/output.go
@@ -84,6 +84,9 @@ func Output(w io.Writer, g *Generator, pkg string, skipCode bool, esdoc bool) {
 		} else {
 			imports["encoding/json"] = true
 		}
+		for _, str := range s.importTypes {
+			imports[str] = true
+		}
 	}
 
 	if len(imports) > 0 {
@@ -168,6 +171,8 @@ func Output(w io.Writer, g *Generator, pkg string, skipCode bool, esdoc bool) {
 			ftype := f.Type
 			if ftype == "int" {
 				ftype = "int64"
+			} else if ftype == "string" && f.Format == "date-time" {
+				ftype = "time.Time"
 			}
 			if f.Format == "raw" {
 				ftype = "json.RawMessage"
@@ -215,8 +220,8 @@ func (strct *%s) MarshalJSON() ([]byte, error) {
 
 			fmt.Fprintf(w,
 				`    // Marshal the "%[1]s" field
-    if comma { 
-        buf.WriteString(",") 
+    if comma {
+        buf.WriteString(",")
     }
     buf.WriteString("\"%[1]s\": ")
 	if tmp, err := json.Marshal(strct.%[2]s); err != nil {

--- a/test/calendar.json
+++ b/test/calendar.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Calendar",
+    "description": "A calendar",
+    "type": "object",
+    "properties": {
+        "date": {
+            "description": "A date",
+            "type": "string",
+            "format": "date-time"
+        }
+    },
+    "required": [
+        "date"
+    ]
+}
+

--- a/test/calendar_test.go
+++ b/test/calendar_test.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	calendar "github.com/elastic/go-json-schema-generate/test/calendar_gen"
+)
+
+func TestCalendar(t *testing.T) {
+	data := []byte(`{
+	"date": "2022-01-02T12:00:00Z"
+    }`)
+	cal := &calendar.Calendar{}
+	if err := json.Unmarshal(data, &cal); err != nil {
+		t.Fatal(err)
+	}
+	ts := time.Date(2022, 1, 2, 12, 0, 0, 0, time.UTC)
+	if !cal.Date.Equal(ts) {
+		t.Errorf("expected date to be %v got %v", ts, cal.Date)
+	}
+}


### PR DESCRIPTION
Support decoding string/date-time in the json schema to a time.Time in
golang. This is done by adding a new internal attribute that will track
additional (golang) imports that a struct needs to import for code
generation.

- Relates https://github.com/a-h/generate/issues/69