### PR TITLE
Generate `uuid.UUID` members for `uuid` jsonschema format

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -75,7 +75,7 @@ func formatCustomTypes() map[string]stringFormatType {
 			TypeName:    "time.Time",
 		},
 		"uuid": {
-			PackageName: "uuid",
+			PackageName: "github.com/google/uuid",
 			TypeName:    "uuid.UUID",
 		},
 	}

--- a/generator.go
+++ b/generator.go
@@ -10,10 +10,12 @@ import (
 
 // Generator will produce structs from the JSON schema.
 type Generator struct {
-	schemas           []*Schema
-	resolver          *RefResolver
-	Structs           map[string]Struct
-	Aliases           map[string]Field
+	schemas  []*Schema
+	resolver *RefResolver
+	Structs  map[string]Struct
+	Aliases  map[string]Field
+	// provides the mapping of "string field with explicitly specified `format`"
+	// to Go typed member of the generated struct for this format
 	customStringTypes map[string]stringFormatType
 	// cache for reference types; k=url v=type
 	refs      map[string]string
@@ -28,13 +30,11 @@ type stringFormatType struct {
 // New creates an instance of a generator which will produce structs.
 func New(schemas ...*Schema) *Generator {
 	return &Generator{
-		schemas:  schemas,
-		resolver: NewRefResolver(schemas),
-		Structs:  make(map[string]Struct),
-		Aliases:  make(map[string]Field),
-		refs:     make(map[string]string),
-		// provides the mapping of "string field with explicitly specified `format`"
-		// to Go typed member of the generated struct for this format
+		schemas:           schemas,
+		resolver:          NewRefResolver(schemas),
+		Structs:           make(map[string]Struct),
+		Aliases:           make(map[string]Field),
+		refs:              make(map[string]string),
 		customStringTypes: formatCustomTypes(),
 	}
 }

--- a/generator.go
+++ b/generator.go
@@ -10,13 +10,19 @@ import (
 
 // Generator will produce structs from the JSON schema.
 type Generator struct {
-	schemas  []*Schema
-	resolver *RefResolver
-	Structs  map[string]Struct
-	Aliases  map[string]Field
+	schemas           []*Schema
+	resolver          *RefResolver
+	Structs           map[string]Struct
+	Aliases           map[string]Field
+	customStringTypes map[string]stringFormatType
 	// cache for reference types; k=url v=type
 	refs      map[string]string
 	anonCount int
+}
+
+type stringFormatType struct {
+	PackageName string
+	TypeName    string
 }
 
 // New creates an instance of a generator which will produce structs.
@@ -27,6 +33,9 @@ func New(schemas ...*Schema) *Generator {
 		Structs:  make(map[string]Struct),
 		Aliases:  make(map[string]Field),
 		refs:     make(map[string]string),
+		// provides the mapping of "string field with explicitly specified `format`"
+		// to Go typed member of the generated struct for this format
+		customStringTypes: formatCustomTypes(),
 	}
 }
 
@@ -57,6 +66,19 @@ func (g *Generator) CreateTypes(conventions map[string]string) (err error) {
 		}
 	}
 	return
+}
+
+func formatCustomTypes() map[string]stringFormatType {
+	return map[string]stringFormatType{
+		"date-time": {
+			PackageName: "time",
+			TypeName:    "time.Time",
+		},
+		"uuid": {
+			PackageName: "uuid",
+			TypeName:    "uuid.UUID",
+		},
+	}
 }
 
 // process a block of definitions
@@ -108,7 +130,7 @@ func (g *Generator) processSchema(schemaName string, schema *Schema, conventions
 			}
 			switch schemaType {
 			case "object":
-				rv, err := g.processObject(name, schema, conventions)
+				rv, err := g.processObject(name, schema, conventions, g.customStringTypes)
 				if err != nil {
 					return "", err
 				}
@@ -175,7 +197,12 @@ func (g *Generator) processArray(name string, schema *Schema, conventions map[st
 // name: name of the struct (calculated by caller)
 // schema: detail incl properties & child objects
 // returns: generated type
-func (g *Generator) processObject(name string, schema *Schema, conventions map[string]string) (typ string, err error) {
+func (g *Generator) processObject(
+	name string,
+	schema *Schema,
+	conventions map[string]string,
+	customTypes map[string]stringFormatType,
+) (typ string, err error) {
 	strct := Struct{
 		ID:          schema.ID(),
 		Name:        name,
@@ -201,8 +228,10 @@ func (g *Generator) processObject(name string, schema *Schema, conventions map[s
 			Description: prop.Description,
 			Format:      prop.Format,
 		}
-		if f.Type == "string" && f.Format == "date-time" {
-			strct.importTypes = append(strct.importTypes, "time")
+		if f.Type == "string" && f.Format != "" {
+			if customTypeForFormat, ok := customTypes[f.Format]; ok {
+				strct.importTypes = append(strct.importTypes, customTypeForFormat.PackageName)
+			}
 		}
 		if f.Required {
 			strct.GenerateCode = true

--- a/generator_test.go
+++ b/generator_test.go
@@ -813,6 +813,19 @@ func TestImportTypeDetection(t *testing.T) {
 			},
 		},
 		expect: []string{"time"},
+	}, {
+		name: "string/uuid imports uuid",
+		input: &Schema{
+			Title:     "example",
+			TypeValue: "object",
+			Properties: map[string]*Schema{
+				"key": {
+					TypeValue: "string",
+					Format:    "uuid",
+				},
+			},
+		},
+		expect: []string{"uuid"},
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/elastic/go-json-schema-generate
 
 go 1.15
+
+require (
+	github.com/google/uuid v1.4.0 // indirect
+)

--- a/output.go
+++ b/output.go
@@ -171,8 +171,10 @@ func Output(w io.Writer, g *Generator, pkg string, skipCode bool, esdoc bool) {
 			ftype := f.Type
 			if ftype == "int" {
 				ftype = "int64"
-			} else if ftype == "string" && f.Format == "date-time" {
-				ftype = "time.Time"
+			} else if ftype == "string" && f.Format != "" {
+				if customStringType, ok := g.customStringTypes[f.Format]; ok {
+					ftype = customStringType.TypeName
+				}
 			}
 			if f.Format == "raw" {
 				ftype = "json.RawMessage"

--- a/test/uuid.json
+++ b/test/uuid.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UUID",
+  "description": "A json schema with a uuid property",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "A UUID",
+      "type": "string",
+      "format": "uuid"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}
+

--- a/test/uuid_test.go
+++ b/test/uuid_test.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+	"encoding/json"
+	uuidGen "github.com/elastic/go-json-schema-generate/test/uuid_gen"
+	"github.com/google/uuid"
+	"testing"
+)
+
+func TestUUID(t *testing.T) {
+	data := []byte(`{
+	"id": "f1c85b8a-3872-40d1-84db-6c0cb9c3ca23"
+    }`)
+	uuidStruct := &uuidGen.UUID{}
+	if err := json.Unmarshal(data, &uuidStruct); err != nil {
+		t.Fatal(err)
+	}
+	expectedUUID, err := uuid.Parse("f1c85b8a-3872-40d1-84db-6c0cb9c3ca23")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uuidStruct.Id != expectedUUID {
+		t.Errorf("expected uuid to be %s got %s", expectedUUID.String(), uuidStruct.Id.String())
+	}
+}


### PR DESCRIPTION
This PR enables the generation of `uuid.UUID` golang struct members based on jsonschema string fields with specified `format` parameter with value "uuid".

The current solution of a similar problem - the "date-time" format - is done with a concrete handling for "date-time". The PR includes a slight generalisation where the `Generator` holds a map for each specific jsonschema format handling.